### PR TITLE
Fix the month displayed on the chart

### DIFF
--- a/template.go
+++ b/template.go
@@ -120,7 +120,7 @@ func makeTemplate() *template.Template {
 			return template.JSEscapeString(strings.TrimSpace(v))
 		},
 		"NewJsDate": func(v time.Time) string {
-			return fmt.Sprintf("new Date(%d,%d,%d,%d,%d)", v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute())
+			return fmt.Sprintf("new Date(%d,%d,%d,%d,%d)", v.Year(), v.Month() - 1, v.Day(), v.Hour(), v.Minute())
 		},
 		"DateFormat": func(v time.Time, format string) string {
 			return v.Format(format)


### PR DESCRIPTION
## Overview

Fix the month displayed on the chart. Google charts months are indexed starting at zero.

ref. https://developers.google.com/chart/interactive/docs/datesandtimes

>  In JavaScript Date objects, months are indexed starting at zero and go up through eleven, with January being month 0 and December being month 11.

So, The display is off by one month now.

## example
now:

```
echo '0 18 * * fri weekend' | go run cronv/main.go -o weekend_now.html -d 30d --from-date=2021/03/01
```

<img width="1891" alt="Cron_Tasks___2021_3_1_16_05___30d" src="https://user-images.githubusercontent.com/13991035/110431631-641c9300-80f1-11eb-9d90-e117654ded31.png">

fixed

```
echo '0 18 * * fri weekend' | go run cronv/main.go -o weekend_fixed.html -d 30d --from-date=2021/03/01
```

<img width="1908" alt="Cron_Tasks___2021_3_1_16_06___30d" src="https://user-images.githubusercontent.com/13991035/110431796-9b8b3f80-80f1-11eb-8cd3-58fc040c79e8.png">



